### PR TITLE
update one_region_per_playlist_migration for Mysql strict sql_mode

### DIFF
--- a/db/migrations/20180131122645_one_region_per_playlist_migration.php
+++ b/db/migrations/20180131122645_one_region_per_playlist_migration.php
@@ -13,8 +13,8 @@ class OneRegionPerPlaylistMigration extends AbstractMigration
         $playlist = $this->table('playlist');
         $playlist
             ->addColumn('regionId', 'integer', ['null' => true])
-            ->addColumn('createdDt', 'datetime')
-            ->addColumn('modifiedDt', 'datetime')
+            ->addColumn('createdDt', 'datetime', ['default' => 'CURRENT_TIMESTAMP'])
+            ->addColumn('modifiedDt', 'datetime', ['default' => 'CURRENT_TIMESTAMP'])
             ->addColumn('duration', 'integer', ['default' => 0])
             ->addColumn('requiresDurationUpdate', 'integer', ['default' => 0, 'limit' => \Phinx\Db\Adapter\MysqlAdapter::INT_TINY])
             ->save();


### PR DESCRIPTION
A default needs to be specified for datetime columns in MySQL 5.7+ default SQL_Mode or there will be an error.  This sets the default value on the createdDt and modifiedDt columns to the current timestamp.